### PR TITLE
Resolve build errors with deprecated symbol names

### DIFF
--- a/api/src/main/java/org/openmrs/module/referenceapplication/ReferenceApplicationActivator.java
+++ b/api/src/main/java/org/openmrs/module/referenceapplication/ReferenceApplicationActivator.java
@@ -213,12 +213,12 @@ public class ReferenceApplicationActivator extends BaseModuleActivator {
 			processHL7Task.setRepeatInterval(ReferenceApplicationConstants.PROCESS_HL7_TASK_INTERVAL);
 			
 			try {
-				schedulerService.saveTask(processHL7Task);
+				schedulerService.saveTaskDefinition(processHL7Task);
 			}
 			catch (NoSuchMethodError ex) {
 				//platform 2.0 renamed saveTask to saveTaskDefinition
 				try {
-					Method method = schedulerService.getClass().getMethod("saveTaskDefinition", new Class[] { TaskDefinition.class });
+					Method method = schedulerService.getClass().getMethod("saveTask", new Class[] { TaskDefinition.class });
 					method.invoke(schedulerService, processHL7Task);
 				}
 				catch (NoSuchMethodException e) {

--- a/api/src/test/java/org/openmrs/module/referenceapplication/ReferenceApplicationActivatorTest.java
+++ b/api/src/test/java/org/openmrs/module/referenceapplication/ReferenceApplicationActivatorTest.java
@@ -37,7 +37,7 @@ public class ReferenceApplicationActivatorTest {
 		
 		new ReferenceApplicationActivator().setupHL7ProcessingTask(schedulerService);
 		
-		verify(schedulerService, never()).saveTask(Matchers.any(TaskDefinition.class));
+		verify(schedulerService, never()).saveTaskDefinition(Matchers.any(TaskDefinition.class));
 	}
 	
 	@Test
@@ -47,7 +47,7 @@ public class ReferenceApplicationActivatorTest {
 		
 		new ReferenceApplicationActivator().setupHL7ProcessingTask(schedulerService);
 		
-		verify(schedulerService).saveTask(Matchers.argThat(new BaseMatcher<TaskDefinition>() {
+		verify(schedulerService).saveTaskDefinition(Matchers.argThat(new BaseMatcher<TaskDefinition>() {
 			
 			@Override
 			public boolean matches(Object obj) {

--- a/omod/src/test/java/org/openmrs/module/referenceapplication/page/controller/LoginPageControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/referenceapplication/page/controller/LoginPageControllerTest.java
@@ -78,6 +78,8 @@ public class LoginPageControllerTest {
 	
 	private static final String GET_LOCATIONS = "Get Locations";
 
+	private static final String VIEW_LOCATIONS = "View Locations";
+
 	private final UiUtils uiUtils = new UiUtils() {
 
 		@Override
@@ -119,8 +121,8 @@ public class LoginPageControllerTest {
 		when(location.hasTag(Mockito.eq(EmrApiConstants.LOCATION_TAG_SUPPORTS_LOGIN))).thenReturn(locationHasLoginTag);
 		when(locationService.getLocation(Mockito.eq(SESSION_LOCATION_ID))).thenReturn(location);
 		spy(Context.class);
-		doNothing().when(Context.class, "addProxyPrivilege", PrivilegeConstants.VIEW_LOCATIONS);
-		doNothing().when(Context.class, "removeProxyPrivilege", PrivilegeConstants.VIEW_LOCATIONS);
+		doNothing().when(Context.class, "addProxyPrivilege", VIEW_LOCATIONS);
+		doNothing().when(Context.class, "removeProxyPrivilege", VIEW_LOCATIONS);
 		doNothing().when(Context.class, "addProxyPrivilege", GET_LOCATIONS);
 		doNothing().when(Context.class, "removeProxyPrivilege", GET_LOCATIONS);
 		doNothing().when(Context.class, "authenticate", USERNAME, PASSWORD);


### PR DESCRIPTION
Fix the "Symbol not found" compile errors when building from scratch.