### PR TITLE
RA-807 Added label translations for Manage visit types

### DIFF
--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -105,3 +105,5 @@ referenceapplication.configuremetadata=Configure Metadata
 
 referenceapplication.formentryapp.manageforms.label=Manage Forms
 
+general.auditInfo=Audit Info
+


### PR DESCRIPTION
# Description

The pages from the [Mange Visit types](https://github.com/suthagar23/openmrs-module-adminui/tree/ebd826450caf8119db314bead633d7155a679ee7/omod/src/main/webapp/pages/metadata/visits/visittypes/templates) need these translation labels for the Ref App. 

# Ticket 

Ticket : https://issues.openmrs.org/browse/RA-807