### PR TITLE
RA-1408 ERROR: demo.openmrs.org redirected you too many times

### DIFF
--- a/omod/src/main/java/org/openmrs/module/referenceapplication/page/controller/LoginPageController.java
+++ b/omod/src/main/java/org/openmrs/module/referenceapplication/page/controller/LoginPageController.java
@@ -68,7 +68,12 @@ public class LoginPageController {
 	@RequestMapping("/login.htm")
 	public String overrideLoginpage() {
 		//TODO The referer should actually be captured from here since we are doing a redirect
-		return "forward:/" + ReferenceApplicationConstants.MODULE_ID + "/login.page";
+
+		//Fixes the RA-1408 Redirection Issue. Redirects to home.page if user is logged in, else redirects to login.page
+		if(Context.isAuthenticated())
+			return "forward:/" + ReferenceApplicationConstants.MODULE_ID + "/home.page";
+		else
+			return "forward:/" + ReferenceApplicationConstants.MODULE_ID + "/login.page";
 	}
 
 	/**


### PR DESCRIPTION
### Description of what I changed

I have modified the function overrideLoginpage() which is under @RequestMapping("/login.htm"): 
     1. Checks to see if User is authenticated 
     2. If user is authenticated, redirects to 'home.page' when "/login.htm" is requested. 
     3. If user is not authenticated, redirects to 'login.page' when "/login.htm" is requested. 

### Issue I worked on 

see https://issues.openmrs.org/browse/RA-1408