### PR TITLE
TRA-258: Filter user input in referer header

### DIFF
--- a/omod/src/main/webapp/pages/login.gsp
+++ b/omod/src/main/webapp/pages/login.gsp
@@ -187,8 +187,7 @@
                             </p>
                             <% } %>
                         </fieldset>
-
-                        <input type="hidden" name="redirectUrl" value="${redirectUrl}" />
+                        <input type="hidden" name="redirectUrl" value="${ui.encodeHtmlAttribute(redirectUrl)}" />
 
                     </form>
                 </div>


### PR DESCRIPTION
**Why**
The `redirectUrl` parameter is user-controlled through the HTTP referer header. This may enable reflected XSS under some circumstances without proper sanitization.

**What Changed**
Unsafe characters such as `'`, and `"` are html-encoded to allow one instance or `redirectUrl` to be used safely within an html attribute.

**Decisions Made**
Used standard ui-framework html-encoding functions (backed by OWASP encoders) to secure the parameter.