### PR TITLE
RA-923: Manage Extension page in the UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ omod/src/main/webapp/resources/styles/login.css
 omod/src/main/webapp/resources/styles/customVariables.css
 omod/src/main/webapp/resources/styles/referenceapplication.css
 omod/src/main/webapp/resources/styles/manageApps.css
+omod/src/main/webapp/resources/styles/manageExtensions.css
 
 # Rubygems build directories #
 omod/.rubygems

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -54,11 +54,14 @@ referenceapplication.app.manageApps.disable.success=Successfully disabled {0}
 referenceapplication.app.manageApps.disable.fail=Failed to disable {0}
 referenceapplication.app.manageApps.delete.success=Successfully deleted {0}
 referenceapplication.app.manageApps.delete.fail=Failed to delete {0}
+referenceapplication.app.manageExtensions.title=Manage Extensions
+referenceapplication.app.manageExtensions.heading=Manage Extensions
 referenceapplication.app.manageModules.title=Manage Modules
 referenceapplication.app.systemInfo.title=System Information
 referenceapplication.app.manageScheduler.title=Manage Scheduler
 referenceapplication.app.addAppDefinition=Add App Definition
 referenceapplication.app.appId.label=App ID
+referenceapplication.app.extensionId.label=Extension ID
 referenceapplication.app.status.label=Status
 referenceapplication.app.type.label=Type
 referenceapplication.app.actions.label=Actions
@@ -76,6 +79,7 @@ referenceapplication.app.userApp.add=Add App Definition
 referenceapplication.app.userApp.edit=Edit App Definition
 referenceapplication.app.userApp.save.success=Successfully saved {0}
 referenceapplication.app.userApp.save.fail=Failed to save {0}
+
 
 
 #========== ERROR MESSAGES =========

--- a/omod/src/main/compass/sass/manageExtensions.scss
+++ b/omod/src/main/compass/sass/manageExtensions.scss
@@ -1,0 +1,23 @@
+.play-action {
+  position: relative;
+  display: inline;
+  text-decoration: none;
+  color: #bbbbbb;
+  font-size: 1em;
+  cursor: pointer;
+}
+.play-action:hover {
+  color: #00cc00;
+}
+
+.stop-action {
+  position: relative;
+  display: inline;
+  text-decoration: none;
+  color: #bbbbbb;
+  font-size: 1em;
+  cursor: pointer;
+}
+.stop-action:hover {
+  color: #ff6666;
+}

--- a/omod/src/main/java/org/openmrs/module/referenceapplication/page/controller/ManageExtensionsPageController.java
+++ b/omod/src/main/java/org/openmrs/module/referenceapplication/page/controller/ManageExtensionsPageController.java
@@ -1,0 +1,98 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.module.referenceapplication.page.controller;
+
+import org.openmrs.module.appframework.domain.Extension;
+import org.openmrs.module.appframework.service.AppFrameworkService;
+import org.openmrs.module.uicommons.UiCommonsConstants;
+import org.openmrs.module.uicommons.util.InfoErrorMessageUtil;
+import org.openmrs.ui.framework.UiUtils;
+import org.openmrs.ui.framework.annotation.SpringBean;
+import org.openmrs.ui.framework.page.PageModel;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import javax.servlet.http.HttpSession;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Controller
+public class ManageExtensionsPageController {
+
+	List<String> extensionsThatCannotBeStopped = Arrays.asList("coreapps.systemAdministrationApp");
+
+	public void get(PageModel model, @SpringBean("appFrameworkService") AppFrameworkService service) {
+		addModelAttributes(model, service);
+	}
+	
+	public String post(PageModel model, @RequestParam("id") String id, @RequestParam("action") String action, 
+	                   @SpringBean("appFrameworkService") AppFrameworkService service, HttpSession session, UiUtils ui) {
+		String successMsgCode = "referenceapplication.app.manageExtensions." + action + ".success";
+		String failMessageCode = "referenceapplication.app.manageExtensions." + action + ".fail";
+		try {
+			if ("enable".equals(action)) {
+				service.enableExtension(id);
+			} else if ("disable".equals(action)) {
+				service.disableExtension(id);
+			} else if ("delete".equals(action)) {
+				service.purgeUserApp(service.getUserApp(id));
+			}
+			
+			InfoErrorMessageUtil.flashInfoMessage(session, ui.message(successMsgCode, id));
+
+			return "redirect:referenceapplication/manageExtensions.page";
+		}
+		catch (Exception e) {
+			session.setAttribute(UiCommonsConstants.SESSION_ATTRIBUTE_ERROR_MESSAGE, ui.message(failMessageCode, id));
+		}
+		
+		addModelAttributes(model, service);
+		
+		return null;
+	}
+	
+	private void addModelAttributes(PageModel model, AppFrameworkService service) {
+		List<Extension> allExtensions = service.getAllExtensions(null);
+		List<Extension> enabledExtensions = service.getAllEnabledExtensions();
+		List<String> userExtensionIds = new ArrayList<String>();
+		List<ExtensionModel> extensions = new ArrayList<ExtensionModel>();
+		for (Extension userExtension : service.getExtensionsForCurrentUser()) {
+			userExtensionIds.add(userExtension.getId());
+		}
+		for (Extension extension : allExtensions) {
+			extensions.add(new ExtensionModel(extension.getId(), enabledExtensions.contains(extension), !userExtensionIds.contains(extension.getId())));
+		}
+		model.addAttribute("extensions", extensions);
+	}
+	
+	public class ExtensionModel {
+		
+		private String id;
+		
+		private boolean enabled;
+		
+		private boolean builtIn;
+
+		private boolean cannotBeStopped;
+
+		public ExtensionModel(String id, boolean enabled, boolean builtIn) {
+			this.id = id;
+			this.enabled = enabled;
+			this.builtIn = builtIn;
+			this.cannotBeStopped = extensionsThatCannotBeStopped.contains(this.id) ? Boolean.TRUE : Boolean.FALSE;
+		}
+		
+	}
+}

--- a/omod/src/main/resources/apps/manageExtensions_extension.json
+++ b/omod/src/main/resources/apps/manageExtensions_extension.json
@@ -1,0 +1,12 @@
+[
+    {
+        "id": "${project.parent.artifactId}.manageExtensions",
+        "extensionPointId": "systemAdministration.apps",
+        "type": "link",
+        "label": "${project.parent.artifactId}.app.manageExtensions.title",
+        "url": "${project.parent.artifactId}/manageExtensions.page",
+        "icon": "icon-th-list",
+        "order": 0,
+        "requiredPrivilege": "App: ${project.parent.artifactId}.manageExtensions"
+    }
+]

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -185,5 +185,10 @@
         <description>Able to manage app definitions</description>
     </privilege>
 
+	<privilege>
+		<name>App: referenceapplication.manageExtensions</name>
+		<description>Able to manage extension definitions</description>
+	</privilege>
+
 </module>
 

--- a/omod/src/main/webapp/pages/manageExtensions.gsp
+++ b/omod/src/main/webapp/pages/manageExtensions.gsp
@@ -1,0 +1,67 @@
+<%
+    ui.decorateWith("appui", "standardEmrPage", [ title: ui.message("referenceapplication.app.manageExtensions.title") ])
+
+    ui.includeJavascript("referenceapplication", "manageExtensions.js");
+
+    ui.includeCss("referenceapplication", "manageExtensions.css");
+
+    ui.includeJavascript("appui", "jquery-3.4.1.min.js")
+%>
+
+<script type="text/javascript">
+    var breadcrumbs = [
+        { icon: "icon-home", link: '/' + OPENMRS_CONTEXT_PATH + '/index.htm' },
+        { label: "${ ui.message("coreapps.app.systemAdministration.label")}",
+          link: "${ui.pageLink("coreapps", "systemadministration/systemAdministration")}"
+        },
+        { label: "${ ui.message("referenceapplication.app.manageExtensions.title")}"}
+    ];
+</script>
+
+<h2>${ ui.message("referenceapplication.app.manageExtensions.heading")}</h2>
+
+</br></br>
+
+<table class="table table-sm table-responsive-sm table-responsive-md table-responsive-lg table-responsive-xl">
+    <thead>
+    <tr>
+        <th>${ ui.message("referenceapplication.app.extensionId.label")}</th>
+        <th>${ ui.message("referenceapplication.app.status.label")}</th>
+        <th>${ ui.message("referenceapplication.app.actions.label")}</th>
+    </tr>
+    </thead>
+    <% extensions.each { extension -> %>
+    <tbody>
+    <tr>
+        <td>${extension.id}</td>
+        <td>
+            <% if(extension.enabled) { %>
+            ${ui.message("referenceapplication.app.status.enabled")}
+            <% } else { %>
+            ${ui.message("referenceapplication.app.status.disabled")}
+            <% } %>
+        </td>
+        <td>
+            <form id="form-${extension.id}" method="POST">
+            <% if(!extension.cannotBeStopped) { %>
+                <% if(extension.enabled) { %>
+                    <i class="icon-stop stop-action referenceapplication-action"
+                       title="${ ui.message("referenceapplication.app.action.disable") }"></i>
+                    <input type="hidden" name="id" value="${extension.id}"/>
+                    <input type="hidden" name="action" value="disable" />
+                <% } else { %>
+                    <i class="icon-play play-action referenceapplication-action"
+                       title="${ ui.message("referenceapplication.app.action.enable") }"></i>
+                    <input type="hidden" name="id" value="${extension.id}"/>
+                    <input type="hidden" name="action" value="enable" />
+                <% } %>
+            <% } %>
+            </form>
+            <% if(extension.cannotBeStopped) { %>
+                <i class="icon-lock lock-action referenceapplication-action"></i>
+            <% } %>
+        </td>
+    </tr>
+    </tbody>
+    <% } %>
+</table>

--- a/omod/src/main/webapp/resources/scripts/manageExtensions.js
+++ b/omod/src/main/webapp/resources/scripts/manageExtensions.js
@@ -1,0 +1,8 @@
+var jq = jQuery;
+
+jq(function(){
+    jq('.referenceapplication-action').click(function(){
+        jq(this).parent().submit();
+    });
+});
+


### PR DESCRIPTION
This PR adds a Manage Extensions page to the UI based off of the Manage Apps page. It provides the ability to enable and disable built-in extensions.

Ticket ID: https://issues.openmrs.org/browse/RA-923

New "Manage Extensions" button on system administration page:
<img width="1014" alt="Screenshot 2020-02-24 at 10 50 00" src="https://user-images.githubusercontent.com/7607425/75142459-7056cd80-56f3-11ea-9cdd-c5d131bead2b.png">

Manage Extensions page:
<img width="1021" alt="Screenshot 2020-02-24 at 12 00 02" src="https://user-images.githubusercontent.com/7607425/75147284-3985b500-56fd-11ea-975e-5ad522dc7840.png">
