### PR TITLE
RA-1775: RequireLoginLocationFilter logic concentrated in config.xml.

### DIFF
--- a/omod/src/main/java/org/openmrs/module/referenceapplication/filter/RequireLoginLocationFilter.java
+++ b/omod/src/main/java/org/openmrs/module/referenceapplication/filter/RequireLoginLocationFilter.java
@@ -94,18 +94,14 @@ public class RequireLoginLocationFilter implements Filter {
 	}
 	
 	/**
-	 * Determines if the filter should be skipped for the specified request uri, typically all requests
-	 * for static content, non ref app pages, login and logout are be ignored.
+	 * Determines if the filter should be skipped for the specified request uri.
+	 * in config.xml file, the filter-mapping is configured to match *.page  and /
 	 * 
 	 * @param requestUri the request uri to check
 	 * @return true if the filter should be skipped otherwise false
 	 */
 	private boolean skipFilter(String requestUri) {
-		if (requestUri.endsWith(".page")) {
-			return ArrayUtils.indexOf(allowedRequestURIs, requestUri) > -1;
-		}
-		
-		return true;
+		return ArrayUtils.indexOf(allowedRequestURIs, requestUri) > -1;
 	}
 	
 	/**

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -74,7 +74,8 @@
 
     <filter-mapping>
         <filter-name>${project.parent.artifactId}RequireLoginLocationFilter</filter-name>
-        <url-pattern>/*</url-pattern>
+        <url-pattern>/</url-pattern>
+        <url-pattern>*.page</url-pattern>
     </filter-mapping>
 
 	Internationalization -->


### PR DESCRIPTION
See https://issues.openmrs.org/browse/RA-1775

the fix:
 - modify the filter-mapping in `config.xml` to map to `*.page `and `/`  to the filter `RequireLoginLocationFilter`
 - Simplify the method `org.openmrs.module.referenceapplication.filter.RequireLoginLocationFilter#skipFilter` as the filter-mapping performs a filter on .page resources.