### PR TITLE
RA-1908: LoginPageController to set the "clientTimezone" user property.

### DIFF
--- a/omod/src/main/java/org/openmrs/module/referenceapplication/page/controller/LoginPageController.java
+++ b/omod/src/main/java/org/openmrs/module/referenceapplication/page/controller/LoginPageController.java
@@ -242,7 +242,7 @@ public class LoginPageController {
 		if (sessionLocationId != null) {
 			try {
 				if (StringUtils.isNotEmpty(clientTimezone)) {
-					ui.setClientTimezoneProperty(clientTimezone);
+					ui.setClientTimezone(clientTimezone);
 				}
 				// TODO as above, grant this privilege to Anonymous instead of using a proxy privilege
 				Context.addProxyPrivilege(VIEW_LOCATIONS);

--- a/omod/src/main/java/org/openmrs/module/referenceapplication/page/controller/LoginPageController.java
+++ b/omod/src/main/java/org/openmrs/module/referenceapplication/page/controller/LoginPageController.java
@@ -242,7 +242,7 @@ public class LoginPageController {
 		if (sessionLocationId != null) {
 			try {
 				if (StringUtils.isNotEmpty(clientTimezone)) {
-					ui.setClientTimezoneProprerty(clientTimezone);
+					ui.setClientTimezoneProperty(clientTimezone);
 				}
 				// TODO as above, grant this privilege to Anonymous instead of using a proxy privilege
 				Context.addProxyPrivilege(VIEW_LOCATIONS);

--- a/omod/src/main/java/org/openmrs/module/referenceapplication/page/controller/LoginPageController.java
+++ b/omod/src/main/java/org/openmrs/module/referenceapplication/page/controller/LoginPageController.java
@@ -230,7 +230,7 @@ public class LoginPageController {
 	public String post(@RequestParam(value = "username", required = false) String username,
 	                   @RequestParam(value = "password", required = false) String password,
 	                   @RequestParam(value = "sessionLocation", required = false) Integer sessionLocationId,
-					   @RequestParam(value = "client-timezone", required = false) String clientTimezone,
+					   @RequestParam(value = "clientTimezone", required = false) String clientTimezone,
 	                   @SpringBean("locationService") LocationService locationService,
 	                   @SpringBean("adminService") AdministrationService administrationService, UiUtils ui,
 	                   @SpringBean("appFrameworkService") AppFrameworkService appFrameworkService, PageRequest pageRequest,
@@ -241,7 +241,7 @@ public class LoginPageController {
 		Location sessionLocation = null;
 		if (sessionLocationId != null) {
 			try {
-				if(StringUtils.isNotEmpty(clientTimezone)){
+				if (StringUtils.isNotEmpty(clientTimezone)) {
 					ui.setClientTimezoneProprerty(clientTimezone);
 				}
 				// TODO as above, grant this privilege to Anonymous instead of using a proxy privilege
@@ -268,14 +268,14 @@ public class LoginPageController {
 					}
 					
 					//If there is a single login location, default to that
-					Boolean clientTimezonePropriety = false;
+					boolean clientTimezoneProperty = false;
 					if(Context.isAuthenticated()){
-						clientTimezonePropriety = StringUtils.isBlank(Context.getAuthenticatedUser().getUserProperty("clientTimezone"));
+						clientTimezoneProperty = StringUtils.isBlank(Context.getAuthenticatedUser().getUserProperty("clientTimezone"));
 					}
 					if (sessionLocation == null) {
 						List<Location> loginLocations = appFrameworkService.getLoginLocations();
 						if (loginLocations.size() == 1) {
-							if(!ui.convertTimezones() || (ui.convertTimezones() && !clientTimezonePropriety)){
+							if(!ui.convertTimezones() || (ui.convertTimezones() && !clientTimezoneProperty)){
 								sessionLocation = loginLocations.get(0);
 							}
 

--- a/omod/src/main/java/org/openmrs/module/referenceapplication/page/controller/LoginPageController.java
+++ b/omod/src/main/java/org/openmrs/module/referenceapplication/page/controller/LoginPageController.java
@@ -269,13 +269,13 @@ public class LoginPageController {
 					
 					//If there is a single login location, default to that
 					boolean clientTimezoneProperty = false;
-					if(Context.isAuthenticated()){
+					if (Context.isAuthenticated()) {
 						clientTimezoneProperty = StringUtils.isBlank(Context.getAuthenticatedUser().getUserProperty("clientTimezone"));
 					}
 					if (sessionLocation == null) {
 						List<Location> loginLocations = appFrameworkService.getLoginLocations();
 						if (loginLocations.size() == 1) {
-							if(!ui.convertTimezones() || (ui.convertTimezones() && !clientTimezoneProperty)){
+							if (!ui.convertTimezones() || (ui.convertTimezones() && !clientTimezoneProperty)) {
 								sessionLocation = loginLocations.get(0);
 							}
 

--- a/omod/src/main/java/org/openmrs/module/referenceapplication/page/controller/LoginPageController.java
+++ b/omod/src/main/java/org/openmrs/module/referenceapplication/page/controller/LoginPageController.java
@@ -230,6 +230,7 @@ public class LoginPageController {
 	public String post(@RequestParam(value = "username", required = false) String username,
 	                   @RequestParam(value = "password", required = false) String password,
 	                   @RequestParam(value = "sessionLocation", required = false) Integer sessionLocationId,
+					   @RequestParam(value = "client-timezone", required = false) String clientTimezone,
 	                   @SpringBean("locationService") LocationService locationService,
 	                   @SpringBean("adminService") AdministrationService administrationService, UiUtils ui,
 	                   @SpringBean("appFrameworkService") AppFrameworkService appFrameworkService, PageRequest pageRequest,
@@ -240,6 +241,9 @@ public class LoginPageController {
 		Location sessionLocation = null;
 		if (sessionLocationId != null) {
 			try {
+				if(StringUtils.isNotEmpty(clientTimezone)){
+					ui.setClientTimezoneProprerty(clientTimezone);
+				}
 				// TODO as above, grant this privilege to Anonymous instead of using a proxy privilege
 				Context.addProxyPrivilege(VIEW_LOCATIONS);
 				Context.addProxyPrivilege(GET_LOCATIONS);
@@ -264,10 +268,17 @@ public class LoginPageController {
 					}
 					
 					//If there is a single login location, default to that
+					Boolean clientTimezonePropriety = false;
+					if(Context.isAuthenticated()){
+						clientTimezonePropriety = StringUtils.isBlank(Context.getAuthenticatedUser().getUserProperty("clientTimezone"));
+					}
 					if (sessionLocation == null) {
 						List<Location> loginLocations = appFrameworkService.getLoginLocations();
 						if (loginLocations.size() == 1) {
-							sessionLocation = loginLocations.get(0);
+							if(!ui.convertTimezones() || (ui.convertTimezones() && !clientTimezonePropriety)){
+								sessionLocation = loginLocations.get(0);
+							}
+
 						}
 					}
 					

--- a/omod/src/main/webapp/pages/login.gsp
+++ b/omod/src/main/webapp/pages/login.gsp
@@ -109,8 +109,8 @@
 
 <script type="text/javascript">
     jq(document).ready(function () {
-        if(jq("#client-timezone").length){
-            jq("#client-timezone").val(Intl.DateTimeFormat().resolvedOptions().timeZone)
+        if(jq("#clientTimezone").length){
+            jq("#clientTimezone").val(Intl.DateTimeFormat().resolvedOptions().timeZone)
         }
     });
 </script>
@@ -171,7 +171,7 @@
                                     <% } %>
                                 </ul>
                             <% if(ui.convertTimezones()) { %>
-                                <input type="hidden" id="client-timezone" name="client-timezone">
+                                <input type="hidden" id="clientTimezone" name="clientTimezone">
                             <%} %>
                             </p>
 

--- a/omod/src/main/webapp/pages/login.gsp
+++ b/omod/src/main/webapp/pages/login.gsp
@@ -170,7 +170,7 @@
                                     <li id="${ui.encodeHtml(it.name)}" tabindex="0"  value="${it.id}">${ui.encodeHtmlContent(ui.format(it))}</li>
                                     <% } %>
                                 </ul>
-                            <% if(ui.convertTimezones()) { %>
+                            <% if (ui.convertTimezones()) { %>
                                 <input type="hidden" id="clientTimezone" name="clientTimezone">
                             <%} %>
                             </p>

--- a/omod/src/main/webapp/pages/login.gsp
+++ b/omod/src/main/webapp/pages/login.gsp
@@ -107,6 +107,14 @@
     });
 </script>
 
+<script type="text/javascript">
+    jq(document).ready(function () {
+        if(jq("#client-timezone").length){
+            jq("#client-timezone").val(Intl.DateTimeFormat().resolvedOptions().timeZone)
+        }
+    });
+</script>
+
 <div id="content" class="container-fluid">
     <div class= "row">
         <div class="col-12 col-sm-12 col-md-12 col-lg-12">
@@ -162,6 +170,9 @@
                                     <li id="${ui.encodeHtml(it.name)}" tabindex="0"  value="${it.id}">${ui.encodeHtmlContent(ui.format(it))}</li>
                                     <% } %>
                                 </ul>
+                            <% if(ui.convertTimezones()) { %>
+                                <input type="hidden" id="client-timezone" name="client-timezone">
+                            <%} %>
                             </p>
 
                             <input type="hidden" id="sessionLocationInput" name="sessionLocation"

--- a/omod/src/test/java/org/openmrs/module/referenceapplication/page/controller/LoginPageControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/referenceapplication/page/controller/LoginPageControllerTest.java
@@ -93,7 +93,9 @@ public class LoginPageControllerTest {
 	private static final String VIEW_LOCATIONS = "View Locations";
 	
 	private final UiUtils uiUtils = new UiUtils() {
-		
+		@Override
+		public boolean convertTimezones() {return  false;}
+
 		@Override
 		public String pageLink(String providerName, String pageName) {
 			return new BasicUiUtils().pageLink(providerName, pageName);
@@ -114,6 +116,7 @@ public class LoginPageControllerTest {
 	@Before
 	public void setup() {
 		mockStatic(Context.class);
+
 		locationService = mock(LocationService.class);
 		sessionContext = mock(UiSessionContext.class);
 		appFrameworkService = mock(AppFrameworkService.class);
@@ -365,7 +368,7 @@ public class LoginPageControllerTest {
 		
 		mockAuthenticatedUser();
 		
-		assertEquals(homeRedirect, new LoginPageController().post(USERNAME, PASSWORD, SESSION_LOCATION_ID, locationService,
+		assertEquals(homeRedirect, new LoginPageController().post(USERNAME, PASSWORD, SESSION_LOCATION_ID, null,locationService,
 		    administrationService, uiUtils, null, pageRequest, sessionContext));
 	}
 	
@@ -389,7 +392,7 @@ public class LoginPageControllerTest {
 		mockAuthenticatedUser();
 		
 		assertEquals("redirect:" + redirectUrl, new LoginPageController().post(USERNAME, PASSWORD, SESSION_LOCATION_ID,
-		    locationService, administrationService, uiUtils, null, pageRequest, sessionContext));
+				null, locationService, administrationService, uiUtils, null, pageRequest, sessionContext));
 	}
 	
 	/**
@@ -410,8 +413,8 @@ public class LoginPageControllerTest {
 		
 		mockAuthenticatedUser();
 		
-		assertEquals(homeRedirect, new LoginPageController().post(USERNAME, PASSWORD, SESSION_LOCATION_ID, locationService,
-		    administrationService, uiUtils, null, pageRequest, sessionContext));
+		assertEquals(homeRedirect, new LoginPageController().post(USERNAME, PASSWORD, SESSION_LOCATION_ID, null,locationService,
+				 administrationService, uiUtils, null, pageRequest, sessionContext));
 		
 	}
 	
@@ -434,7 +437,7 @@ public class LoginPageControllerTest {
 	public void post_shouldSendTheUserBackToTheLoginPageWhenAuthenticationFails() throws Exception {
 		when(Context.isAuthenticated()).thenReturn(false);
 		MockHttpServletRequest request = new MockHttpServletRequest();
-		String page = new LoginPageController().post(null, null, SESSION_LOCATION_ID, locationService, administrationService,
+		String page = new LoginPageController().post(null, null, SESSION_LOCATION_ID, null, locationService,  administrationService,
 		    uiUtils, appFrameworkService, createPageRequest(request, null), sessionContext);
 		assertEquals("redirect:" + uiUtils.pageLink("referenceapplication", "login"), page);
 	}
@@ -448,7 +451,7 @@ public class LoginPageControllerTest {
 	public void post_shouldSendTheUserBackToTheLoginPageIfAnInvalidLocationIsSelected() throws Exception {
 		setupMocksForSuccessfulAuthentication(false);
 		MockHttpServletRequest request = new MockHttpServletRequest();
-		String page = new LoginPageController().post(USERNAME, PASSWORD, SESSION_LOCATION_ID, locationService,
+		String page = new LoginPageController().post(USERNAME, PASSWORD, SESSION_LOCATION_ID, null, locationService,
 		    administrationService, uiUtils, null, createPageRequest(request, null), sessionContext);
 		assertEquals("redirect:" + uiUtils.pageLink("referenceapplication", "login"), page);
 	}
@@ -543,7 +546,7 @@ public class LoginPageControllerTest {
 		ConversionService conversionService = mock(ConversionService.class);
 		when(conversionService.convert(eq(true), eq(String.class))).thenReturn("true");
 		Whitebox.setInternalState(uiUtils, "conversionService", conversionService);
-		String page = new LoginPageController().post(USERNAME, PASSWORD, null, locationService, administrationService,
+		String page = new LoginPageController().post(USERNAME, PASSWORD, null, null, locationService, administrationService,
 		    uiUtils, appFrameworkService, createPageRequest(request, null), sessionContext);
 		assertEquals(expectedPage, page);
 	}
@@ -596,7 +599,7 @@ public class LoginPageControllerTest {
 		when(administrationService.getGlobalProperty(eq(ReferenceApplicationConstants.LOCATION_USER_PROPERTY_NAME)))
 		        .thenReturn("someValue");
 		
-		assertEquals(homeRedirect, new LoginPageController().post(USERNAME, PASSWORD, null, locationService,
+		assertEquals(homeRedirect, new LoginPageController().post(USERNAME, PASSWORD, null,null, locationService,
 		    administrationService, uiUtils, appFrameworkService, pageRequest, sessionContext));
 		
 		verify(sessionContext, times(1)).setSessionLocation(eq(location));

--- a/omod/src/test/java/org/openmrs/module/referenceapplication/page/controller/LoginPageControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/referenceapplication/page/controller/LoginPageControllerTest.java
@@ -624,17 +624,17 @@ public class LoginPageControllerTest {
 	public void post_shouldNotAutoSelectALocationAfterAuthenticationIfLoginLocationsSizeIsOneAndUsingTimezonesWithoutClientTimezone() throws Exception {
 		when(Context.isAuthenticated()).thenReturn(false).thenReturn(true);
 		when(Context.getAuthenticatedUser()).thenReturn(mock(User.class));
-		final int locationId = 1;
-		final String locationSelectionPage = "redirect:/openmrs/" + ReferenceApplicationConstants.MODULE_ID + "/login.page";
+		final int LOCATIONID = 1;
+		final String LOCATIONSELECTIONPAGE = "redirect:/openmrs/" + ReferenceApplicationConstants.MODULE_ID + "/login.page";
 		PageRequest pageRequest = createPageRequest(new MockHttpServletRequest(), null);
 
-		Location location = new Location(locationId);
+		Location location = new Location(LOCATIONID);
 		location.addTag(new LocationTag(EmrApiConstants.LOCATION_TAG_SUPPORTS_LOGIN, null));
 		when(appFrameworkService.getLoginLocations()).thenReturn(Collections.singletonList(location));
 		when(administrationService.getGlobalProperty(eq(ReferenceApplicationConstants.LOCATION_USER_PROPERTY_NAME)))
 				.thenReturn("someValue");
 
-		assertEquals(locationSelectionPage, new LoginPageController().post(USERNAME, PASSWORD, null, null, locationService,
+		assertEquals(LOCATIONSELECTIONPAGE, new LoginPageController().post(USERNAME, PASSWORD, null, null, locationService,
 				administrationService, uiUtilsWithTimezone, appFrameworkService, pageRequest, sessionContext));
 
 	}

--- a/omod/src/test/java/org/openmrs/module/referenceapplication/page/controller/LoginPageControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/referenceapplication/page/controller/LoginPageControllerTest.java
@@ -599,7 +599,7 @@ public class LoginPageControllerTest {
 		when(administrationService.getGlobalProperty(eq(ReferenceApplicationConstants.LOCATION_USER_PROPERTY_NAME)))
 		        .thenReturn("someValue");
 		
-		assertEquals(homeRedirect, new LoginPageController().post(USERNAME, PASSWORD, null,null, locationService,
+		assertEquals(homeRedirect, new LoginPageController().post(USERNAME, PASSWORD, null, null, locationService,
 		    administrationService, uiUtils, appFrameworkService, pageRequest, sessionContext));
 		
 		verify(sessionContext, times(1)).setSessionLocation(eq(location));

--- a/omod/src/test/java/org/openmrs/module/referenceapplication/page/controller/LoginPageControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/referenceapplication/page/controller/LoginPageControllerTest.java
@@ -368,7 +368,7 @@ public class LoginPageControllerTest {
 		
 		mockAuthenticatedUser();
 		
-		assertEquals(homeRedirect, new LoginPageController().post(USERNAME, PASSWORD, SESSION_LOCATION_ID, null,locationService,
+		assertEquals(homeRedirect, new LoginPageController().post(USERNAME, PASSWORD, SESSION_LOCATION_ID, null, locationService,
 		    administrationService, uiUtils, null, pageRequest, sessionContext));
 	}
 	
@@ -413,7 +413,7 @@ public class LoginPageControllerTest {
 		
 		mockAuthenticatedUser();
 		
-		assertEquals(homeRedirect, new LoginPageController().post(USERNAME, PASSWORD, SESSION_LOCATION_ID, null,locationService,
+		assertEquals(homeRedirect, new LoginPageController().post(USERNAME, PASSWORD, SESSION_LOCATION_ID, null, locationService,
 				 administrationService, uiUtils, null, pageRequest, sessionContext));
 		
 	}

--- a/omod/src/test/java/org/openmrs/module/referenceapplication/page/controller/LoginPageControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/referenceapplication/page/controller/LoginPageControllerTest.java
@@ -92,7 +92,7 @@ public class LoginPageControllerTest {
 	
 	private static final String VIEW_LOCATIONS = "View Locations";
 	
-	private final UiUtils uiUtils = new UiUtils() {
+	private final UiUtils uiUtilsWithoutTimezones = new UiUtils() {
 		@Override
 		public boolean convertTimezones() {return  false;}
 
@@ -101,6 +101,21 @@ public class LoginPageControllerTest {
 			return new BasicUiUtils().pageLink(providerName, pageName);
 		}
 		
+		@Override
+		public String message(String code, Object... args) {
+			return null;
+		}
+	};
+
+	private final UiUtils uiUtilsWithTimezone = new UiUtils() {
+		@Override
+		public boolean convertTimezones() {return  true;}
+
+		@Override
+		public String pageLink(String providerName, String pageName) {
+			return new BasicUiUtils().pageLink(providerName, pageName);
+		}
+
 		@Override
 		public String message(String code, Object... args) {
 			return null;
@@ -172,8 +187,8 @@ public class LoginPageControllerTest {
 	    throws Exception {
 		when(Context.isAuthenticated()).thenReturn(true);
 		when(Context.getUserContext()).thenReturn(mock(UserContext.class));
-		String homeRedirect = "redirect:" + uiUtils.pageLink(ReferenceApplicationConstants.MODULE_ID, "home");
-		assertEquals(homeRedirect, new LoginPageController().get(null, uiUtils, createPageRequest(null, null), null, null,
+		String homeRedirect = "redirect:" + uiUtilsWithoutTimezones.pageLink(ReferenceApplicationConstants.MODULE_ID, "home");
+		assertEquals(homeRedirect, new LoginPageController().get(null, uiUtilsWithoutTimezones, createPageRequest(null, null), null, null,
 		    appFrameworkService, administrationService));
 	}
 	
@@ -188,7 +203,7 @@ public class LoginPageControllerTest {
 	@Verifies(value = "should show the user the login page if they are not authenticated", method = "get(PageModel,UiUtils,PageRequest)")
 	public void get_shouldShowTheUserTheLoginPageIfTheyAreNotAuthenticated() throws Exception {
 		when(Context.isAuthenticated()).thenReturn(false);
-		assertNull(new LoginPageController().get(new PageModel(), uiUtils, createPageRequest(null, null), null, null,
+		assertNull(new LoginPageController().get(new PageModel(), uiUtilsWithoutTimezones, createPageRequest(null, null), null, null,
 		    appFrameworkService, administrationService));
 	}
 	
@@ -210,7 +225,7 @@ public class LoginPageControllerTest {
 		request.addParameter(REQUEST_PARAMETER_NAME_REDIRECT_URL, redirectUrl);
 		PageModel pageModel = new PageModel();
 		
-		new LoginPageController().get(pageModel, uiUtils, createPageRequest(request, null), null, null, appFrameworkService,
+		new LoginPageController().get(pageModel, uiUtilsWithoutTimezones, createPageRequest(request, null), null, null, appFrameworkService,
 		    administrationService);
 		
 		assertEquals(redirectUrl, pageModel.get(REQUEST_PARAMETER_NAME_REDIRECT_URL));
@@ -234,7 +249,7 @@ public class LoginPageControllerTest {
 		request.addHeader("Referer", refererUrl);
 		PageModel pageModel = new PageModel();
 		
-		new LoginPageController().get(pageModel, uiUtils, createPageRequest(request, null), null, null, appFrameworkService,
+		new LoginPageController().get(pageModel, uiUtilsWithoutTimezones, createPageRequest(request, null), null, null, appFrameworkService,
 		    administrationService);
 		
 		assertEquals(refererUrl, pageModel.get(REQUEST_PARAMETER_NAME_REDIRECT_URL));
@@ -261,7 +276,7 @@ public class LoginPageControllerTest {
 		request.setSession(httpSession);
 		
 		PageModel pageModel = new PageModel();
-		new LoginPageController().get(pageModel, uiUtils, pageRequest, null, null, appFrameworkService,
+		new LoginPageController().get(pageModel, uiUtilsWithoutTimezones, pageRequest, null, null, appFrameworkService,
 		    administrationService);
 		
 		assertEquals(redirectUrl, pageModel.get(REQUEST_PARAMETER_NAME_REDIRECT_URL));
@@ -289,7 +304,7 @@ public class LoginPageControllerTest {
 		
 		PageModel pageModel = new PageModel();
 		
-		assertEquals("redirect:" + redirectUrl, new LoginPageController().get(pageModel, uiUtils, pageRequest, null, null,
+		assertEquals("redirect:" + redirectUrl, new LoginPageController().get(pageModel, uiUtilsWithoutTimezones, pageRequest, null, null,
 		    appFrameworkService, administrationService));
 	}
 	
@@ -316,7 +331,7 @@ public class LoginPageControllerTest {
 		
 		PageModel pageModel = new PageModel();
 		
-		assertNotEquals("redirect:" + redirectUrl, new LoginPageController().get(pageModel, uiUtils, pageRequest, null, null,
+		assertNotEquals("redirect:" + redirectUrl, new LoginPageController().get(pageModel, uiUtilsWithoutTimezones, pageRequest, null, null,
 		    appFrameworkService, administrationService));
 	}
 	
@@ -329,7 +344,7 @@ public class LoginPageControllerTest {
 	public void get_shouldNotSetRedirectUrlParamAfterManualLogout() throws Exception {
 		when(Context.isAuthenticated()).thenReturn(false);
 		
-		final String homeRedirect = "redirect:" + uiUtils.pageLink(ReferenceApplicationConstants.MODULE_ID, "home");
+		final String homeRedirect = "redirect:" + uiUtilsWithoutTimezones.pageLink(ReferenceApplicationConstants.MODULE_ID, "home");
 		
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.addHeader("Referer", "somePage/weDont/wantTo/beRedirected");
@@ -340,7 +355,7 @@ public class LoginPageControllerTest {
 		
 		PageModel pageModel = new PageModel();
 		
-		new LoginPageController().get(pageModel, uiUtils, pageRequest, null, null, appFrameworkService,
+		new LoginPageController().get(pageModel, uiUtilsWithoutTimezones, pageRequest, null, null, appFrameworkService,
 		    administrationService);
 		
 		assertEquals("", pageModel.getAttribute(ReferenceApplicationWebConstants.REQUEST_PARAMETER_NAME_REDIRECT_URL));
@@ -356,7 +371,7 @@ public class LoginPageControllerTest {
 	public void post_shouldRedirectNewUserToHome() throws Exception {
 		setupMocksForSuccessfulAuthentication(true);
 		
-		final String homeRedirect = "redirect:" + uiUtils.pageLink(ReferenceApplicationConstants.MODULE_ID, "home");
+		final String homeRedirect = "redirect:" + uiUtilsWithoutTimezones.pageLink(ReferenceApplicationConstants.MODULE_ID, "home");
 		String redirectUrl = TEST_CONTEXT_PATH + "/referenceapplication/patient.page";
 		
 		MockHttpServletRequest request = new MockHttpServletRequest();
@@ -369,7 +384,7 @@ public class LoginPageControllerTest {
 		mockAuthenticatedUser();
 		
 		assertEquals(homeRedirect, new LoginPageController().post(USERNAME, PASSWORD, SESSION_LOCATION_ID, null, locationService,
-		    administrationService, uiUtils, null, pageRequest, sessionContext));
+		    administrationService, uiUtilsWithoutTimezones, null, pageRequest, sessionContext));
 	}
 	
 	/**
@@ -392,7 +407,7 @@ public class LoginPageControllerTest {
 		mockAuthenticatedUser();
 		
 		assertEquals("redirect:" + redirectUrl, new LoginPageController().post(USERNAME, PASSWORD, SESSION_LOCATION_ID,
-				null, locationService, administrationService, uiUtils, null, pageRequest, sessionContext));
+				null, locationService, administrationService, uiUtilsWithoutTimezones, null, pageRequest, sessionContext));
 	}
 	
 	/**
@@ -404,8 +419,8 @@ public class LoginPageControllerTest {
 	public void post_shouldRedirectTheUserToTheHomePageIfTheRedirectUrlIsTheLoginPage() throws Exception {
 		setupMocksForSuccessfulAuthentication(true);
 		
-		final String redirectUrl = uiUtils.pageLink(ReferenceApplicationConstants.MODULE_ID, "login");
-		final String homeRedirect = "redirect:" + uiUtils.pageLink(ReferenceApplicationConstants.MODULE_ID, "home");
+		final String redirectUrl = uiUtilsWithoutTimezones.pageLink(ReferenceApplicationConstants.MODULE_ID, "login");
+		final String homeRedirect = "redirect:" + uiUtilsWithoutTimezones.pageLink(ReferenceApplicationConstants.MODULE_ID, "home");
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setContextPath("/openmrs");
 		request.setParameter(REQUEST_PARAMETER_NAME_REDIRECT_URL, redirectUrl);
@@ -414,7 +429,7 @@ public class LoginPageControllerTest {
 		mockAuthenticatedUser();
 		
 		assertEquals(homeRedirect, new LoginPageController().post(USERNAME, PASSWORD, SESSION_LOCATION_ID, null, locationService,
-				 administrationService, uiUtils, null, pageRequest, sessionContext));
+				 administrationService, uiUtilsWithoutTimezones, null, pageRequest, sessionContext));
 		
 	}
 	
@@ -438,8 +453,8 @@ public class LoginPageControllerTest {
 		when(Context.isAuthenticated()).thenReturn(false);
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		String page = new LoginPageController().post(null, null, SESSION_LOCATION_ID, null, locationService,  administrationService,
-		    uiUtils, appFrameworkService, createPageRequest(request, null), sessionContext);
-		assertEquals("redirect:" + uiUtils.pageLink("referenceapplication", "login"), page);
+				uiUtilsWithoutTimezones, appFrameworkService, createPageRequest(request, null), sessionContext);
+		assertEquals("redirect:" + uiUtilsWithoutTimezones.pageLink("referenceapplication", "login"), page);
 	}
 	
 	/**
@@ -452,8 +467,8 @@ public class LoginPageControllerTest {
 		setupMocksForSuccessfulAuthentication(false);
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		String page = new LoginPageController().post(USERNAME, PASSWORD, SESSION_LOCATION_ID, null, locationService,
-		    administrationService, uiUtils, null, createPageRequest(request, null), sessionContext);
-		assertEquals("redirect:" + uiUtils.pageLink("referenceapplication", "login"), page);
+		    administrationService, uiUtilsWithoutTimezones, null, createPageRequest(request, null), sessionContext);
+		assertEquals("redirect:" + uiUtilsWithoutTimezones.pageLink("referenceapplication", "login"), page);
 	}
 	
 	/**
@@ -471,7 +486,7 @@ public class LoginPageControllerTest {
 		request.setContextPath(TEST_CONTEXT_PATH);
 		request.addHeader("Referer", refererUrl);
 		PageModel pageModel = new PageModel();
-		new LoginPageController().get(pageModel, uiUtils, createPageRequest(request, null), null, null, appFrameworkService,
+		new LoginPageController().get(pageModel, uiUtilsWithoutTimezones, createPageRequest(request, null), null, null, appFrameworkService,
 		    administrationService);
 		
 		assertEquals("", pageModel.get(REQUEST_PARAMETER_NAME_REDIRECT_URL));
@@ -493,7 +508,7 @@ public class LoginPageControllerTest {
 		request.setContextPath(TEST_CONTEXT_PATH);
 		request.addHeader("Referer", refererUrl);
 		PageModel pageModel = new PageModel();
-		new LoginPageController().get(pageModel, uiUtils, createPageRequest(request, null), null, null, appFrameworkService,
+		new LoginPageController().get(pageModel, uiUtilsWithoutTimezones, createPageRequest(request, null), null, null, appFrameworkService,
 		    administrationService);
 		
 		assertEquals(redirectUrl, pageModel.get(REQUEST_PARAMETER_NAME_REDIRECT_URL));
@@ -524,7 +539,7 @@ public class LoginPageControllerTest {
 		
 		PageModel pageModel = new PageModel();
 		
-		assertEquals("redirect:" + redirectUrl, new LoginPageController().get(pageModel, uiUtils, pageRequest, null, null,
+		assertEquals("redirect:" + redirectUrl, new LoginPageController().get(pageModel, uiUtilsWithoutTimezones, pageRequest, null, null,
 		    appFrameworkService, administrationService));
 	}
 	
@@ -545,9 +560,9 @@ public class LoginPageControllerTest {
 		final String expectedPage = "redirect:/openmrs/" + ReferenceApplicationConstants.MODULE_ID + "/login.page";
 		ConversionService conversionService = mock(ConversionService.class);
 		when(conversionService.convert(eq(true), eq(String.class))).thenReturn("true");
-		Whitebox.setInternalState(uiUtils, "conversionService", conversionService);
+		Whitebox.setInternalState(uiUtilsWithoutTimezones, "conversionService", conversionService);
 		String page = new LoginPageController().post(USERNAME, PASSWORD, null, null, locationService, administrationService,
-		    uiUtils, appFrameworkService, createPageRequest(request, null), sessionContext);
+				uiUtilsWithoutTimezones, appFrameworkService, createPageRequest(request, null), sessionContext);
 		assertEquals(expectedPage, page);
 	}
 	
@@ -577,7 +592,7 @@ public class LoginPageControllerTest {
 		PageRequest pageRequest = createPageRequest(request, null);
 		PageModel pageModel = new PageModel();
 		
-		assertNull(new LoginPageController().get(pageModel, uiUtils, pageRequest, null, locationService, appFrameworkService,
+		assertNull(new LoginPageController().get(pageModel, uiUtilsWithoutTimezones, pageRequest, null, locationService, appFrameworkService,
 		    administrationService));
 		List<Location> locations = (List) pageModel.getAttribute("locations");
 		assertEquals(2, locations.size());
@@ -590,7 +605,7 @@ public class LoginPageControllerTest {
 		when(Context.isAuthenticated()).thenReturn(false).thenReturn(true);
 		when(Context.getAuthenticatedUser()).thenReturn(mock(User.class));
 		final int locationId = 1;
-		final String homeRedirect = "redirect:" + uiUtils.pageLink(ReferenceApplicationConstants.MODULE_ID, "home");
+		final String homeRedirect = "redirect:" + uiUtilsWithoutTimezones.pageLink(ReferenceApplicationConstants.MODULE_ID, "home");
 		PageRequest pageRequest = createPageRequest(new MockHttpServletRequest(), null);
 		
 		Location location = new Location(locationId);
@@ -600,9 +615,28 @@ public class LoginPageControllerTest {
 		        .thenReturn("someValue");
 		
 		assertEquals(homeRedirect, new LoginPageController().post(USERNAME, PASSWORD, null, null, locationService,
-		    administrationService, uiUtils, appFrameworkService, pageRequest, sessionContext));
+		    administrationService, uiUtilsWithoutTimezones, appFrameworkService, pageRequest, sessionContext));
 		
 		verify(sessionContext, times(1)).setSessionLocation(eq(location));
 	}
-	
+
+	@Test
+	public void post_shouldNotAutoSelectALocationAfterAuthenticationIfLoginLocationsSizeIsOneAndUsingTimezonesWithoutClientTimezone() throws Exception {
+		when(Context.isAuthenticated()).thenReturn(false).thenReturn(true);
+		when(Context.getAuthenticatedUser()).thenReturn(mock(User.class));
+		final int locationId = 1;
+		final String locationSelectionPage = "redirect:/openmrs/" + ReferenceApplicationConstants.MODULE_ID + "/login.page";
+		PageRequest pageRequest = createPageRequest(new MockHttpServletRequest(), null);
+
+		Location location = new Location(locationId);
+		location.addTag(new LocationTag(EmrApiConstants.LOCATION_TAG_SUPPORTS_LOGIN, null));
+		when(appFrameworkService.getLoginLocations()).thenReturn(Collections.singletonList(location));
+		when(administrationService.getGlobalProperty(eq(ReferenceApplicationConstants.LOCATION_USER_PROPERTY_NAME)))
+				.thenReturn("someValue");
+
+		assertEquals(locationSelectionPage, new LoginPageController().post(USERNAME, PASSWORD, null, null, locationService,
+				administrationService, uiUtilsWithTimezone, appFrameworkService, pageRequest, sessionContext));
+
+	}
+
 }

--- a/omod/src/test/java/org/openmrs/module/referenceapplication/page/controller/LoginPageControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/referenceapplication/page/controller/LoginPageControllerTest.java
@@ -624,17 +624,17 @@ public class LoginPageControllerTest {
 	public void post_shouldNotAutoSelectALocationAfterAuthenticationIfLoginLocationsSizeIsOneAndUsingTimezonesWithoutClientTimezone() throws Exception {
 		when(Context.isAuthenticated()).thenReturn(false).thenReturn(true);
 		when(Context.getAuthenticatedUser()).thenReturn(mock(User.class));
-		final int LOCATIONID = 1;
-		final String LOCATIONSELECTIONPAGE = "redirect:/openmrs/" + ReferenceApplicationConstants.MODULE_ID + "/login.page";
+		final int LOCATION_ID = 1;
+		final String LOCATION_SELECTION_PAGE = "redirect:/openmrs/" + ReferenceApplicationConstants.MODULE_ID + "/login.page";
 		PageRequest pageRequest = createPageRequest(new MockHttpServletRequest(), null);
 
-		Location location = new Location(LOCATIONID);
+		Location location = new Location(LOCATION_ID);
 		location.addTag(new LocationTag(EmrApiConstants.LOCATION_TAG_SUPPORTS_LOGIN, null));
 		when(appFrameworkService.getLoginLocations()).thenReturn(Collections.singletonList(location));
 		when(administrationService.getGlobalProperty(eq(ReferenceApplicationConstants.LOCATION_USER_PROPERTY_NAME)))
 				.thenReturn("someValue");
 
-		assertEquals(LOCATIONSELECTIONPAGE, new LoginPageController().post(USERNAME, PASSWORD, null, null, locationService,
+		assertEquals(LOCATION_SELECTION_PAGE, new LoginPageController().post(USERNAME, PASSWORD, null, null, locationService,
 				administrationService, uiUtilsWithTimezone, appFrameworkService, pageRequest, sessionContext));
 
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 		<metadatasharingVersion>1.2.2</metadatasharingVersion>
 		<emrapiVersion>1.21.0</emrapiVersion>
 		<providermanagementVersion>2.5.0</providermanagementVersion>
-		<uiframeworkVersion>3.9</uiframeworkVersion>
+		<uiframeworkVersion>3.21.0-SNAPSHOT</uiframeworkVersion>
 		<appuiVersion>1.7</appuiVersion>
 		<atlasVersion>2.2</atlasVersion>
 		<eventVersion>2.8.0</eventVersion>


### PR DESCRIPTION
#### Ticket:
https://issues.openmrs.org/browse/RA-1908
#### What I have done:
Setting the `"clientTimezone"` user property after selecting a location on the second login screen.
There is a special case that has been covered:
* `IF` only one location is available
* `AND` if time zones conversions are enabled through the `"timezone.conversions"` GP
* `AND` the user property `"clientTimezone"` is **not** set
* `THEN` it will force the user to select that single location to trigger setting the user property.

We also updated UIFR  to be 3.21.0-SNAPSHOT.