### PR TITLE
RA-1875: EMPT110 Fixed XSS Vulnerability in AppId field on User App Page

### DIFF
--- a/omod/src/main/java/org/openmrs/module/referenceapplication/page/controller/UserAppPageController.java
+++ b/omod/src/main/java/org/openmrs/module/referenceapplication/page/controller/UserAppPageController.java
@@ -54,27 +54,26 @@ public class UserAppPageController {
 	                   @RequestParam("action") String action,
 	                   @SpringBean("appFrameworkService") AppFrameworkService service, HttpSession session, UiUtils ui) {
 
-		String htmlSafeAppId = StringEscapeUtils.escapeHtml(userApp.getAppId());
 		try {
 			AppDescriptor descriptor = mapper.readValue(userApp.getJson(), AppDescriptor.class);
-			if (!htmlSafeAppId.equals(descriptor.getId())) {
+			if (!userApp.getAppId().equals(descriptor.getId())) {
 				session.setAttribute(UiCommonsConstants.SESSION_ATTRIBUTE_ERROR_MESSAGE,
 				    ui.message("referenceapplication.app.errors.IdsShouldMatch"));
-			} else if ("add".equals(action) && service.getUserApp(htmlSafeAppId) != null) {
+			} else if ("add".equals(action) && service.getUserApp(userApp.getAppId()) != null) {
 				session.setAttribute(UiCommonsConstants.SESSION_ATTRIBUTE_ERROR_MESSAGE,
 				    ui.message("referenceapplication.app.errors.duplicateAppId"));
 			} else {
 				service.saveUserApp(userApp);
 				
 				InfoErrorMessageUtil.flashInfoMessage(session,
-				    ui.message("referenceapplication.app.userApp.save.success", htmlSafeAppId));
+				    ui.message("referenceapplication.app.userApp.save.success", StringEscapeUtils.escapeHtml(userApp.getAppId())));
 				
 				return "redirect:/referenceapplication/manageApps.page";
 			}
 		}
 		catch (Exception e) {
 			session.setAttribute(UiCommonsConstants.SESSION_ATTRIBUTE_ERROR_MESSAGE,
-			    ui.message("referenceapplication.app.userApp.save.fail", htmlSafeAppId));
+			    ui.message("referenceapplication.app.userApp.save.fail", StringEscapeUtils.escapeHtml(userApp.getAppId())));
 		}
 		
 		model.addAttribute("userApp", userApp);

--- a/omod/src/main/java/org/openmrs/module/referenceapplication/page/controller/UserAppPageController.java
+++ b/omod/src/main/java/org/openmrs/module/referenceapplication/page/controller/UserAppPageController.java
@@ -15,6 +15,7 @@ package org.openmrs.module.referenceapplication.page.controller;
 
 import javax.servlet.http.HttpSession;
 
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -52,27 +53,28 @@ public class UserAppPageController {
 	public String post(PageModel model, @ModelAttribute(value = "appId") @BindParams UserApp userApp,
 	                   @RequestParam("action") String action,
 	                   @SpringBean("appFrameworkService") AppFrameworkService service, HttpSession session, UiUtils ui) {
-		
+
+		String htmlSafeAppId = StringEscapeUtils.escapeHtml(userApp.getAppId());
 		try {
 			AppDescriptor descriptor = mapper.readValue(userApp.getJson(), AppDescriptor.class);
-			if (!userApp.getAppId().equals(descriptor.getId())) {
+			if (!htmlSafeAppId.equals(descriptor.getId())) {
 				session.setAttribute(UiCommonsConstants.SESSION_ATTRIBUTE_ERROR_MESSAGE,
 				    ui.message("referenceapplication.app.errors.IdsShouldMatch"));
-			} else if ("add".equals(action) && service.getUserApp(userApp.getAppId()) != null) {
+			} else if ("add".equals(action) && service.getUserApp(htmlSafeAppId) != null) {
 				session.setAttribute(UiCommonsConstants.SESSION_ATTRIBUTE_ERROR_MESSAGE,
 				    ui.message("referenceapplication.app.errors.duplicateAppId"));
 			} else {
 				service.saveUserApp(userApp);
 				
 				InfoErrorMessageUtil.flashInfoMessage(session,
-				    ui.message("referenceapplication.app.userApp.save.success", userApp.getAppId()));
+				    ui.message("referenceapplication.app.userApp.save.success", htmlSafeAppId));
 				
 				return "redirect:/referenceapplication/manageApps.page";
 			}
 		}
 		catch (Exception e) {
 			session.setAttribute(UiCommonsConstants.SESSION_ATTRIBUTE_ERROR_MESSAGE,
-			    ui.message("referenceapplication.app.userApp.save.fail", userApp.getAppId()));
+			    ui.message("referenceapplication.app.userApp.save.fail", htmlSafeAppId));
 		}
 		
 		model.addAttribute("userApp", userApp);


### PR DESCRIPTION
### Description of What I Changed
I encoded the AppId (entered by the user via AppId field) before it is referenced for further processing to prevent any XSS attacks.

### Issue I Worked On

A script or an iframe could be injected in the AppId field while adding app definition. I encoded the AppId in the controller file before it was referenced for usage to prevent any XSS.

Steps to reproduce the vulnerability:

1. Launch the OpenMRS application.
2. Login with username "Admin" and password "Admin123" with location as Inpatient Ward.
3. Click on the “System Administration” option.
4. Click ‘Manage Apps’.
5. Click ‘Add App Definition’.
6. ln the App lD (required) field enter:`</script><script>alert('XSS');</script>`.
7. Right click on the page and select ‘lnspect Element’.
8. ln the ‘Search HTML’ panel of the lnspector tab, search for the HTML for the 'Save' button. Double-click on the ‘disabled=”disabled”’ text and delete hit, then press Enter to save the changes.
9. Click on the Save button (which should now be clickable).

Output: A dialog box pops up with 'XSS' written on it.

### Link to ticket
[RA-1875](https://issues.openmrs.org/browse/RA-1875)

@isears
