### PR TITLE
RA-1958 - Force user to go to location selection screen

### DIFF
--- a/omod/src/main/java/org/openmrs/module/referenceapplication/page/controller/LoginPageController.java
+++ b/omod/src/main/java/org/openmrs/module/referenceapplication/page/controller/LoginPageController.java
@@ -261,7 +261,7 @@ public class LoginPageController {
 				
 				if (isLocationUserPropertyAvailable(administrationService)) {
 					List<Location> accessibleLocations = getUserLocations(administrationService, locationService);
-					if (accessibleLocations.size() == 1) {
+					if (accessibleLocations.size() == 1 && !ui.convertTimezones()) {
 						sessionLocation = accessibleLocations.get(0);
 					} else if (accessibleLocations.size() > 1) {
 						return "redirect:" + ui.pageLink(ReferenceApplicationConstants.MODULE_ID, "login");


### PR DESCRIPTION
**Issue: RA-1958** 
https://issues.openmrs.org/browse/RA-1958

- User will go to location selection even if he only have 1 location associated, if the GP to timezones is true