### PR TITLE
Validate urlPath before execute, prevent null pointer exception

### DIFF
--- a/omod/src/main/java/org/openmrs/module/referenceapplication/page/controller/LoginPageController.java
+++ b/omod/src/main/java/org/openmrs/module/referenceapplication/page/controller/LoginPageController.java
@@ -13,6 +13,7 @@
  */
 package org.openmrs.module.referenceapplication.page.controller;
 
+import javax.validation.Validator;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -162,9 +163,13 @@ public class LoginPageController {
 				try {
 					URL url = new URL(redirectUrl);
 					String urlPath = url.getFile();
-					String urlContextPath = urlPath.substring(1).contains("/") ? urlPath.substring(0, urlPath.indexOf('/', 1)) : urlPath;
-					if (StringUtils.equals(pageRequest.getRequest().getContextPath(), urlContextPath)) {
-						return true;
+					if(StringUtils.isNotEmpty(urlPath)) {
+						String urlContextPath =
+								urlPath.substring(1).contains("/") ? urlPath.substring(0, urlPath.indexOf('/', 1))
+										: urlPath;
+						if (StringUtils.equals(pageRequest.getRequest().getContextPath(), urlContextPath)) {
+							return true;
+						}
 					}
 				}
 				catch (MalformedURLException e) {


### PR DESCRIPTION
### Dear whom it may concern,

I would like to suggest an improvement regarding the operation of Login page which currently produces an issue when the redirect URL context path is blank. Please refer to the screenshot and code change below.

![Selection_204](https://user-images.githubusercontent.com/8575116/147315334-73f4a740-8139-4516-8692-a36bb19cefbc.png)

## Server Info:
open MRS 2.3.2 Build 437b7f

## Step to reproduce:
1. embedded Open MRS portal link in another portal. ex: https://app.abc.com
2. click on the embedded link. ex: https://openmrs.abc.com/openmrs

The error shows up on the second time I redirect to login page.


Thank you very much for considering the improvement.

Best Regards,
Samnang