### PR TITLE
TRUNK-6203: Global properties access should be privileged

### DIFF
--- a/omod/src/main/java/org/openmrs/module/referenceapplication/page/controller/LoginPageController.java
+++ b/omod/src/main/java/org/openmrs/module/referenceapplication/page/controller/LoginPageController.java
@@ -33,6 +33,7 @@ import org.openmrs.ui.framework.UiUtils;
 import org.openmrs.ui.framework.annotation.SpringBean;
 import org.openmrs.ui.framework.page.PageModel;
 import org.openmrs.ui.framework.page.PageRequest;
+import org.openmrs.util.PrivilegeConstants;
 import org.openmrs.web.user.CurrentUsers;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.CookieValue;
@@ -150,9 +151,14 @@ public class LoginPageController {
 	}
 	
 	private boolean isLocationUserPropertyAvailable(AdministrationService administrationService) {
-		String locationUserPropertyName = administrationService
-		        .getGlobalProperty(ReferenceApplicationConstants.LOCATION_USER_PROPERTY_NAME);
-		
+		String locationUserPropertyName;
+		try {
+			Context.addProxyPrivilege(PrivilegeConstants.GET_GLOBAL_PROPERTIES);
+			locationUserPropertyName  = administrationService
+					.getGlobalProperty(ReferenceApplicationConstants.LOCATION_USER_PROPERTY_NAME);
+		} finally {
+			Context.removeProxyPrivilege(PrivilegeConstants.GET_GLOBAL_PROPERTIES);
+		}
 		return StringUtils.isNotBlank(locationUserPropertyName);
 	}
 	


### PR DESCRIPTION
After https://github.com/openmrs/openmrs-core/pull/4601, users must possess the 'Get Global Properties' privilege to access global properties. This grants it as a proxy privilege so users can access essential pages, such as the login page.

Ticket: https://openmrs.atlassian.net/browse/TRUNK-6203